### PR TITLE
Some targets (Influx for example) use alias insted of legendFormat (w…

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -5,7 +5,7 @@ Changelog
 x.x.x ?
 ==================
 
-* Added ...
+* Added support `alias` via the `legendFormat` option for `Target`
 
 0.7.1 2024-01-12
 ==================

--- a/grafanalib/core.py
+++ b/grafanalib/core.py
@@ -573,6 +573,7 @@ class Target(object):
     Metric to show.
 
     :param target: Graphite way to select data
+    :param legendFormat: Target alias. Prometheus use legendFormat, other like Influx use alias. This set legendFormat as well as alias.
     """
 
     expr = attr.ib(default="")
@@ -598,6 +599,7 @@ class Target(object):
             'interval': self.interval,
             'intervalFactor': self.intervalFactor,
             'legendFormat': self.legendFormat,
+            'alias': self.legendFormat,
             'metric': self.metric,
             'refId': self.refId,
             'step': self.step,


### PR DESCRIPTION
…hich is Prometheus 'alias'). This commit setup both of them by legendFormat.

<!--
Hi, thanks for this PR! We are really grateful, and deeply appreciate the work and effort involved.

It might take a little while for us to get around to reviewing it. Sorry for the delay.

To help things go as quickly as possible, please:
- update the CHANGELOG in your PR
- keep the PR as small and focused as you can
- follow the coding guidelines found in CONTRIBUTING.rst
-->

## What does this do?
<!-- brief explanation of the functionality this provides -->

## Why is it a good idea?
<!-- how does it help grafanalib users / maintainers? -->

## Context
<!-- any background that might help the reviewer understand what's going on -->

## Questions
<!-- things you're uncertain about that you want the reviewer to focus on -->
